### PR TITLE
Better Local Reference Syntax 

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,14 +103,13 @@ main = do
   htmlSource <- fromMaybe (Lib.callAgdaToHTML verbose useJekyll maybeInputFile agdaSource) istreamHTML
 
   let
-    textBlocks = Lib.text agdaSource
+    rawTextBlocks = Lib.text agdaSource
     codeBlocks = map (linkToAgdaStdlib . stripImplicitArgs) (Lib.code (isJust useJekyll) htmlSource)
-    allBlocks  = T.concat $ blend [textBlocks, codeBlocks]
 
-  output <- (if optLocalRefSugar opts then Lib.postProcess useJekyll maybeInputFile allBlocks
-                                      else return allBlocks)
+  textBlocks <- (if optLocalRefSugar opts then mapM (Lib.postProcess useJekyll maybeInputFile) rawTextBlocks
+                                          else return rawTextBlocks)
 
-  ostream output
+  ostream $ T.concat $ blend [textBlocks, codeBlocks]
 
 -- |Writes to a file, creating the directories if missing.
 writeFileCreateDirectoryIfMissing :: FilePath -> T.Text -> IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -100,9 +100,6 @@ main = do
 
   let (istreamAgda', maybeInputFile) = maybeReadInput istreamAgda
   agdaSource <- istreamAgda'
-  --rawAgdaSource <- istreamAgda'
-  --agdaSource <- if optLocalRefSugar opts then Lib.preProcess useJekyll maybeInputFile rawAgdaSource
-  --                                          else return rawAgdaSource
   htmlSource <- fromMaybe (Lib.callAgdaToHTML verbose useJekyll maybeInputFile agdaSource) istreamHTML
 
   let


### PR DESCRIPTION
Adds an option --local-references allowing us to write [text][agda.module#name] for links to local agda files. 

I'm not sure the #section bit ends up in the right place. Can you comment? (see in particular `workingRefLink :: Replace`)

I ended up doing something a bit gross to get this going without changing too much (some work is done twice). It would be good to refactor things at some point, but I have other priorities at the moment. Can probably spend time working on it in a few months when things calm down.  